### PR TITLE
Remove RetroArch options for Nag/Info/Game screen

### DIFF
--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -282,39 +282,6 @@ video_changed=true;
          cheats_enable = true;
    }
 
-   var.key   = option_nag;
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "disabled"))
-         hide_nagscreen = false;
-      if (!strcmp(var.value, "enabled"))
-         hide_nagscreen = true;
-   }
-
-   var.key   = option_info;
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "disabled"))
-         hide_gameinfo = false;
-      if (!strcmp(var.value, "enabled"))
-         hide_gameinfo = true;
-   }
-
-   var.key   = option_warnings;
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "disabled"))
-         hide_warnings = false;
-      if (!strcmp(var.value, "enabled"))
-         hide_warnings = true;
-   }
-
    var.key   = option_renderer;
    var.value = NULL;
 


### PR DESCRIPTION
Remove these as they won't work when resynced with upstream.